### PR TITLE
feat: agregar servidor y arbitrajes en vivo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     :root{--gap:12px;--radius:14px;font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif}
     body{margin:0;padding:24px;background:#0b0e14;color:#e6e6e6}
     h1{font-size:20px;margin:0 0 12px}
-    .card{background:#111827;border:1px solid #2a2f3a;border-radius:var(--radius);padding:16px;max-width:760px}
+    .card{background:#111827;border:1px solid #2a2f3a;border-radius:var(--radius);padding:16px;max-width:760px;margin-bottom:24px}
     .grid{display:grid;gap:var(--gap)}
     .g3{grid-template-columns:repeat(3,1fr)}
     label{font-size:12px;opacity:.8}
@@ -82,10 +82,15 @@
     <div class="muted">Nota: si 1/oa + 1/ox + 1/ob < 1, hay arbitraje y el beneficio es positivo. Sin comisiones ni límites.</div>
   </div>
 
+  <div class="card" id="live">
+    <h2>Arbitrajes en directo</h2>
+    <div id="liveResults" class="grid" style="gap:var(--gap)"></div>
+  </div>
+
   <script>
     const BANK = 100;
     const $ = (id) => document.getElementById(id);
-    const fmt = (n) => isFinite(n) ? n.toFixed(2) : '—';
+    const fmt = (n) => isFinite(n) ? Number(n).toFixed(2) : '—';
 
     function calc(){
       const oa = parseFloat($('oa').value);
@@ -97,20 +102,17 @@
       const invSum = invA + invX + invB;
       const margin = 1 - invSum; // >0 si hay arbitraje
 
-      // Stakes que igualan payout con banca fija BANK
       let sA = BANK * invA / invSum;
       let sX = BANK * invX / invSum;
       let sB = BANK * invB / invSum;
 
-      // Redondeo a céntimos
       sA = Math.round(sA*100)/100;
       sX = Math.round(sX*100)/100;
       sB = Math.round(sB*100)/100;
 
-      // Recalcular totales y payout tras redondeo
       const S = sA + sX + sB;
-      const payoutTheo = BANK / invSum; // teórico sin redondeo
-      const payoutEst = Math.min(sA*oa, sX*ox, sB*ob); // conservador tras redondeo
+      const payoutTheo = BANK / invSum;
+      const payoutEst = Math.min(sA*oa, sX*ox, sB*ob);
       const profitEst = payoutEst - S;
 
       $('arbFlag').innerHTML = margin>0
@@ -129,6 +131,35 @@
     }
 
     ['oa','ox','ob'].forEach(id=>$(id).addEventListener('input',calc));
+
+    async function loadArbitrage(){
+      try {
+        const res = await fetch('/api/arbitrage');
+        const data = await res.json();
+        const container = $('liveResults');
+        if (!data.length) {
+          container.innerHTML = '<div class="muted">Sin oportunidades actualmente</div>';
+          return;
+        }
+        container.innerHTML = '';
+        data.forEach(o => {
+          const div = document.createElement('div');
+          div.className = 'box';
+          div.innerHTML = `
+            <div><b>${o.event}</b></div>
+            <div class="mono">A: ${o.best.home.price} (${o.best.home.bookie}) → apostar ${fmt(o.stake.home)}</div>
+            <div class="mono">X: ${o.best.draw.price} (${o.best.draw.bookie}) → apostar ${fmt(o.stake.draw)}</div>
+            <div class="mono">B: ${o.best.away.price} (${o.best.away.bookie}) → apostar ${fmt(o.stake.away)}</div>
+            <div class="muted mono">Beneficio estimado ${fmt(o.profit)} · ROI ${(o.margin*100).toFixed(2)}%</div>
+          `;
+          container.appendChild(div);
+        });
+      } catch (e) {
+        console.error('Error cargando arbitrajes', e);
+      }
+    }
+
+    loadArbitrage();
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "arbitraje",
+  "version": "1.0.0",
+  "description": "Calculadora de arbitraje con datos en vivo",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/sample-odds.json
+++ b/sample-odds.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "match1",
+    "home_team": "Equipo A",
+    "away_team": "Equipo B",
+    "commence_time": "2024-05-29T12:00:00Z",
+    "bookmakers": [
+      {
+        "title": "Casa1",
+        "markets": [
+          {
+            "key": "h2h",
+            "outcomes": [
+              { "name": "Equipo A", "price": 2.5 },
+              { "name": "Draw", "price": 3.2 },
+              { "name": "Equipo B", "price": 3.3 }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Casa2",
+        "markets": [
+          {
+            "key": "h2h",
+            "outcomes": [
+              { "name": "Equipo A", "price": 2.4 },
+              { "name": "Draw", "price": 3.6 },
+              { "name": "Equipo B", "price": 3.2 }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Casa3",
+        "markets": [
+          {
+            "key": "h2h",
+            "outcomes": [
+              { "name": "Equipo A", "price": 2.3 },
+              { "name": "Draw", "price": 3.4 },
+              { "name": "Equipo B", "price": 3.75 }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "match2",
+    "home_team": "Equipo C",
+    "away_team": "Equipo D",
+    "commence_time": "2024-05-29T15:00:00Z",
+    "bookmakers": [
+      {
+        "title": "Casa1",
+        "markets": [
+          {
+            "key": "h2h",
+            "outcomes": [
+              { "name": "Equipo C", "price": 1.8 },
+              { "name": "Draw", "price": 3.0 },
+              { "name": "Equipo D", "price": 4.0 }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Casa2",
+        "markets": [
+          {
+            "key": "h2h",
+            "outcomes": [
+              { "name": "Equipo C", "price": 1.9 },
+              { "name": "Draw", "price": 3.1 },
+              { "name": "Equipo D", "price": 3.9 }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/server.js
+++ b/server.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const fs = require('fs');
+
+const BANK = 100; // banca fija para calculo de stakes
+let oddsData = [];
+
+async function fetchOdds() {
+  const apiKey = process.env.ODDS_API_KEY;
+  if (apiKey) {
+    try {
+      const url = `https://api.the-odds-api.com/v4/sports/soccer/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=${apiKey}`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      oddsData = await res.json();
+      fs.mkdirSync('data',{recursive:true});
+      fs.writeFileSync('data/odds.json', JSON.stringify(oddsData, null, 2));
+      return;
+    } catch (err) {
+      console.error('Error fetching API, using sample data', err.message);
+    }
+  }
+  oddsData = JSON.parse(fs.readFileSync('sample-odds.json', 'utf-8'));
+}
+
+function computeArbitrage() {
+  const opportunities = [];
+  for (const event of oddsData) {
+    const best = {
+      home: { price: 0, bookie: null },
+      draw: { price: 0, bookie: null },
+      away: { price: 0, bookie: null }
+    };
+
+    for (const book of event.bookmakers || []) {
+      const market = (book.markets || []).find(m => m.key === 'h2h');
+      if (!market) continue;
+      for (const o of market.outcomes) {
+        const key = o.name === 'Draw'
+          ? 'draw'
+          : (o.name === event.home_team ? 'home' : 'away');
+        if (o.price > best[key].price) {
+          best[key] = { price: o.price, bookie: book.title };
+        }
+      }
+    }
+
+    if (!best.home.price || !best.draw.price || !best.away.price) continue;
+
+    const invSum = 1 / best.home.price + 1 / best.draw.price + 1 / best.away.price;
+    const margin = 1 - invSum;
+    if (margin > 0) {
+      let sH = BANK * (1 / best.home.price) / invSum;
+      let sD = BANK * (1 / best.draw.price) / invSum;
+      let sA = BANK * (1 / best.away.price) / invSum;
+      sH = Math.round(sH * 100) / 100;
+      sD = Math.round(sD * 100) / 100;
+      sA = Math.round(sA * 100) / 100;
+      const S = sH + sD + sA;
+      const payout = Math.min(sH * best.home.price, sD * best.draw.price, sA * best.away.price);
+      const profit = payout - S;
+      opportunities.push({
+        event: `${event.home_team} vs ${event.away_team}`,
+        commence_time: event.commence_time,
+        best,
+        stake: { home: sH, draw: sD, away: sA },
+        payout,
+        profit,
+        margin
+      });
+    }
+  }
+  return opportunities;
+}
+
+const app = express();
+app.use(express.static('.'));
+
+app.get('/api/arbitrage', async (req, res) => {
+  await fetchOdds();
+  res.json(computeArbitrage());
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Servidor en http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- add Node/Express server that obtiene cuotas y detecta oportunidades de arbitraje
- incorporar ejemplo de datos de cuotas y nuevo frontend que muestra arbitrajes en vivo

## Testing
- `npm test`
- `node server.js` *(falla: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68c8218709208324b583f1a8189b12bf