### PR TITLE
Mostrar probabilidades según cuotas y retirar arbitraje en vivo

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     .card{background:#111827;border:1px solid #2a2f3a;border-radius:var(--radius);padding:16px;max-width:760px;margin-bottom:24px}
     .grid{display:grid;gap:var(--gap)}
     .g3{grid-template-columns:repeat(3,1fr)}
-    label{font-size:12px;opacity:.8}
+    label{display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:12px;opacity:.8}
     input[type="number"]{width:100%;padding:10px;border-radius:10px;border:1px solid #2a2f3a;background:#0e1525;color:#e6e6e6}
     .muted{opacity:.75;font-size:12px}
     .ok{color:#22c55e}
@@ -20,6 +20,7 @@
     .box{background:#0e1525;border:1px dashed #2a2f3a;border-radius:12px;padding:12px}
     .right{text-align:right}
     small{opacity:.65}
+    .prob{font-variant-numeric:tabular-nums;opacity:.75}
   </style>
 </head>
 <body>
@@ -29,15 +30,15 @@
 
     <div class="grid g3">
       <div>
-        <label>Cuota Gana A</label>
+        <label>Cuota Gana A <span class="prob" id="pa">—</span></label>
         <input id="oa" type="number" step="0.01" min="1.01" placeholder="2.10">
       </div>
       <div>
-        <label>Cuota Empate</label>
+        <label>Cuota Empate <span class="prob" id="px">—</span></label>
         <input id="ox" type="number" step="0.01" min="1.01" placeholder="3.40">
       </div>
       <div>
-        <label>Cuota Gana B</label>
+        <label>Cuota Gana B <span class="prob" id="pb">—</span></label>
         <input id="ob" type="number" step="0.01" min="1.01" placeholder="3.20">
       </div>
     </div>
@@ -82,23 +83,32 @@
     <div class="muted">Nota: si 1/oa + 1/ox + 1/ob < 1, hay arbitraje y el beneficio es positivo. Sin comisiones ni límites.</div>
   </div>
 
-  <div class="card" id="live">
-    <h2>Arbitrajes en directo</h2>
-    <div id="liveResults" class="grid" style="gap:var(--gap)"></div>
-  </div>
-
   <script>
     const BANK = 100;
     const $ = (id) => document.getElementById(id);
     const fmt = (n) => isFinite(n) ? Number(n).toFixed(2) : '—';
+    const fmtPct = (n) => isFinite(n) ? (n * 100).toFixed(2) + '%' : '—';
 
-    function calc(){
+    function setProbability(el, odd) {
+      const prob = odd > 0 ? 1 / odd : NaN;
+      $(el).textContent = fmtPct(prob);
+    }
+
+    function calc() {
       const oa = parseFloat($('oa').value);
       const ox = parseFloat($('ox').value);
       const ob = parseFloat($('ob').value);
-      if (![oa,ox,ob].every(v => v && v>1)) { $('result').style.display='none'; return; }
 
-      const invA = 1/oa, invX = 1/ox, invB = 1/ob;
+      setProbability('pa', oa);
+      setProbability('px', ox);
+      setProbability('pb', ob);
+
+      if (![oa, ox, ob].every(v => v && v > 1)) {
+        $('result').style.display = 'none';
+        return;
+      }
+
+      const invA = 1 / oa, invX = 1 / ox, invB = 1 / ob;
       const invSum = invA + invX + invB;
       const margin = 1 - invSum; // >0 si hay arbitraje
 
@@ -106,18 +116,18 @@
       let sX = BANK * invX / invSum;
       let sB = BANK * invB / invSum;
 
-      sA = Math.round(sA*100)/100;
-      sX = Math.round(sX*100)/100;
-      sB = Math.round(sB*100)/100;
+      sA = Math.round(sA * 100) / 100;
+      sX = Math.round(sX * 100) / 100;
+      sB = Math.round(sB * 100) / 100;
 
       const S = sA + sX + sB;
       const payoutTheo = BANK / invSum;
-      const payoutEst = Math.min(sA*oa, sX*ox, sB*ob);
+      const payoutEst = Math.min(sA * oa, sX * ox, sB * ob);
       const profitEst = payoutEst - S;
 
-      $('arbFlag').innerHTML = margin>0
-        ? `<span class="ok">Arbitraje SÍ</span> · margen ${(margin*100).toFixed(2)}%`
-        : `<span class="bad">Arbitraje NO</span> · overround ${(invSum*100).toFixed(2)}%`;
+      $('arbFlag').innerHTML = margin > 0
+        ? `<span class="ok">Arbitraje SÍ</span> · margen ${(margin * 100).toFixed(2)}%`
+        : `<span class="bad">Arbitraje NO</span> · overround ${(invSum * 100).toFixed(2)}%`;
 
       $('sa').textContent = fmt(sA);
       $('sx').textContent = fmt(sX);
@@ -125,41 +135,14 @@
       $('payout').textContent = fmt(payoutTheo);
       $('inv').textContent = fmt(S);
       $('profit').textContent = fmt(profitEst);
-      $('margin').textContent = `ROI teórico ≈ ${((1/invSum - 1)*100).toFixed(2)}%`;
+      $('margin').textContent = `ROI teórico ≈ ${((1 / invSum - 1) * 100).toFixed(2)}%`;
 
-      $('result').style.display='';
+      $('result').style.display = '';
     }
 
-    ['oa','ox','ob'].forEach(id=>$(id).addEventListener('input',calc));
+    ['oa', 'ox', 'ob'].forEach(id => $(id).addEventListener('input', calc));
 
-    async function loadArbitrage(){
-      try {
-        const res = await fetch('/api/arbitrage');
-        const data = await res.json();
-        const container = $('liveResults');
-        if (!data.length) {
-          container.innerHTML = '<div class="muted">Sin oportunidades actualmente</div>';
-          return;
-        }
-        container.innerHTML = '';
-        data.forEach(o => {
-          const div = document.createElement('div');
-          div.className = 'box';
-          div.innerHTML = `
-            <div><b>${o.event}</b></div>
-            <div class="mono">A: ${o.best.home.price} (${o.best.home.bookie}) → apostar ${fmt(o.stake.home)}</div>
-            <div class="mono">X: ${o.best.draw.price} (${o.best.draw.bookie}) → apostar ${fmt(o.stake.draw)}</div>
-            <div class="mono">B: ${o.best.away.price} (${o.best.away.bookie}) → apostar ${fmt(o.stake.away)}</div>
-            <div class="muted mono">Beneficio estimado ${fmt(o.profit)} · ROI ${(o.margin*100).toFixed(2)}%</div>
-          `;
-          container.appendChild(div);
-        });
-      } catch (e) {
-        console.error('Error cargando arbitrajes', e);
-      }
-    }
-
-    loadArbitrage();
+    calc();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the live arbitrage card and related fetch logic
- show implied win probabilities next to each entered odds using the existing calculator inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8616fa3a88324a988a260e880adeb